### PR TITLE
Fix overflowing image on small screens 

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -224,7 +224,7 @@ Dr.&nbsp;Erin LeDell is the Chief Scientist at Distributional, Inc.&nbsp;where s
 <p><br></p>
 <div class="quarto-figure quarto-figure-center">
 <figure class="figure">
-<p><a href="https://www.r-consortium.org/"><img src="images/R-con.png" class="quarto-figure quarto-figure-center figure-img" alt="R Consortium" height="150"></a></p>
+<p><a href="https://www.r-consortium.org/"><img src="images/R-con.png" class="img-fluid quarto-figure quarto-figure-center figure-img" style="width:90.0%" data-max-height="150" alt="R Consortium"></a></p>
 </figure>
 </div>
 </section>

--- a/index.qmd
+++ b/index.qmd
@@ -59,7 +59,7 @@ Dr. Erin LeDell is the Chief Scientist at Distributional, Inc. where she’s hel
 
 <br>
 
-[![](images/R-con.png){fig-alt="R Consortium" fig-align="center" height="150"}](https://www.r-consortium.org/)
+[![](images/R-con.png){fig-alt="R Consortium" fig-align="center" max-height="150" width="90%"}](https://www.r-consortium.org/)
 
 ## MAILING LIST
 


### PR DESCRIPTION
By replacing `height` with `max-height` and adding a `width` value the image should now not overflow on small screens while still retaining aspect ratio. Originally noticed on mobile.